### PR TITLE
api: Fix unicode issue when trying to add \n to the read file

### DIFF
--- a/frosted/api.py
+++ b/frosted/api.py
@@ -72,7 +72,7 @@ def check_path(filename, reporter=modReporter.Default, **setting_overrides):
     """Check the given path, printing out any warnings detected."""
     try:
         with open(filename, 'U') as f:
-            codestr = f.read() + '\n'
+            codestr = f.read()
     except UnicodeError:
         reporter.unexpected_error(filename, 'problem decoding source')
         return 1


### PR DESCRIPTION
Without this I get errors like:

filename_x: problem decoding source

Digging deeper, and adding traceback printing I see the error is:

Traceback (most recent call last):
  File "/Library/Python/2.7/site-packages/frosted-1.1.2-py2.7.egg/frosted/api.py", line 75, in check_path
    codestr = f.read() + '\n'
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc4 in position 14385: ordinal not in range(128)
