### PR TITLE
Feature/fix issue 30

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ ignored.
 
 **E400 Series** - *Syntax Errors*
 - **E401**: DoctestSyntaxError
+- **E402**: PythonSyntaxError
 
 **W100 Series** - *Exception Warning*
 - **W101**: BareExcept

--- a/frosted/api.py
+++ b/frosted/api.py
@@ -21,7 +21,7 @@ import sys
 
 from frosted import reporter as modReporter
 from frosted import checker, settings
-from frosted.messages import FileSkipped
+from frosted.messages import FileSkipped, PythonSyntaxError
 from pies.overrides import *
 
 import _ast
@@ -52,7 +52,7 @@ def check(codeString, filename, reporter=modReporter.Default, settings_path=None
         elif active_settings.get('verbose', False):
             ignore = active_settings.get('ignore_frosted_errors', [])
             if(not "W200" in ignore and not "W201" in ignore):
-                reporter.flake(FileSkipped(filename))
+                reporter.flake(FileSkipped(filename, verbose=active_settings.get('verbose')))
         return 0
 
     # First, compile into an AST and handle syntax errors.
@@ -71,7 +71,8 @@ def check(codeString, filename, reporter=modReporter.Default, settings_path=None
             # unknown.
             reporter.unexpected_error(filename, 'problem decoding source')
         else:
-            reporter.syntax_error(filename, msg, lineno, offset, text)
+            reporter.flake(PythonSyntaxError(filename, msg, lineno, offset, text,
+                                             verbose=active_settings.get('verbose')))
         return 1
     except Exception:
         reporter.unexpected_error(filename, 'problem decoding source')

--- a/frosted/messages.py
+++ b/frosted/messages.py
@@ -99,3 +99,4 @@ ReturnWithArgsInsideGenerator = MessageType('E208', 'ReturnWithArgsInsideGenerat
                                             "'return' with argument inside generator", 'return')
 BareExcept = MessageType('W101', 'BareExcept', "bare except used: this is dangerous and should be avoided", 'except')
 FileSkipped = MessageType('W201', 'FileSkipped', "Skipped because of the current configuration")
+PythonSyntaxError = MessageType('E402', 'PythonSyntaxError', "{0!s}")

--- a/frosted/reporter.py
+++ b/frosted/reporter.py
@@ -32,19 +32,6 @@ class Reporter(namedtuple('Reporter', ('stdout', 'stderr'))):
         """Output an unexpected_error specific to the provided filename."""
         self.stderr.write("%s: %s\n" % (filename, msg))
 
-    def syntax_error(self, filename, msg, lineno, offset, text):
-        """Output a syntax_error specific to the provided filename."""
-        line = text.splitlines()[-1]
-        if offset is not None:
-            offset = offset - (len(text) - len(line))
-            self.stderr.write('%s:%d:%d: %s\n' % (filename, lineno, offset, msg))
-        else:
-            self.stderr.write('%s:%d: %s\n' % (filename, lineno, msg))
-        self.stderr.write(str(line))
-        self.stderr.write('\n')
-        if offset is not None:
-            self.stderr.write(re.sub(r'\S', ' ', line[:offset]) + "^\n")
-
     def flake(self, message):
         """Print an error message to stdout."""
         self.stdout.write(str(message))


### PR DESCRIPTION
Provides a fix for issue #34 by adding a new PythonSyntaxError message type that replaces direct calling of syntax_error to enable features such as verbose output.
