### PR TITLE
Include license in packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ develop-eggs
 lib
 lib64
 MANIFEST
-MANIFEST.in
 
 # Installer logs
 pip-log.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
Ensures the `MANIFEST.in` is included in `git`. This file should not be ignored by `git` though `MANIFEST` which is generated from `MANIFEST.in` and other resources when making a package should be ignored. Also adds the `LICENSE` file to `MANIFEST.in` to ensure it will be packaged.
